### PR TITLE
Fix building of Nokogiri's native extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ ADD examples/rhea-rails/Gemfile.lock /app/
 
 RUN apk --update add --virtual build-dependencies build-base git \
     libc-dev linux-headers ruby-dev openssl-dev && \
-    gem install bundler && \
-    cd /app; bundle config build.nokogiri --use-system-libraries && \
+    gem install --no-rdoc --no-ri bundler && \
     cd /app; bundle install --deployment --full-index --jobs 4 && \
     apk del build-dependencies
 


### PR DESCRIPTION
While building the image using the existing Dockerfile, I ran into the following:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /app/vendor/bundle/ruby/2.3.0/gems/nokogiri-1.6.8/ext/nokogiri
/usr/bin/ruby -r ./siteconf20160725-18-1hb1fsf.rb extconf.rb --use-system-libraries
Using pkg-config version 1.1.7
checking if the C compiler accepts ... yes
Building nokogiri using system libraries.
checking for libexslt... yes
checking for xmlParseDoc() in libxml/parser.h... no
checking for xmlParseDoc() in -lxml2... no
checking for xmlParseDoc() in -llibxml2... no
-----
libxml2 is missing.  Please locate mkmf.log to investigate how it is failing.
-----
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```

@ayumi, judging from the existing `bundle config build.nokogiri --use-system-libraries` call, it looks like you may've hit a similar issue. Does this new Dockerfile, which fixes the error I was seeing, work for you?