### PR TITLE
Improve the grid structure of commands#index

### DIFF
--- a/app/views/rhea/commands/index.html.haml
+++ b/app/views/rhea/commands/index.html.haml
@@ -1,23 +1,31 @@
 .row
   .col-md-8
-    .pull-left
-      = form_tag commands_path, method: 'GET', class: 'form-inline' do
-        .form-group
-          = label_tag :image, 'Image', style: 'margin-right: 5px; font-size: 13px;'
-          - image_options = [['All', nil]] + @images.map { |image| [humanize_image(image), image] }
-          = select_tag :image, options_for_select(image_options, params[:image].presence), class: 'form-control', onchange: "$(this).closest('form').submit();"
-    .pull-right
-      = form_tag import_commands_path, method: 'PUT', multipart: true, style: 'display: inline-block;' do
-        %span.btn.btn-default.btn-file
-          Import
-          = file_field_tag :data, accept: 'application/json', onchange: "$(this).closest('form').submit();"
-      = link_to 'Export', export_commands_path(format: 'json'), class: 'btn btn-default'
-    - if @commands.present?
-      = form_tag batch_update_commands_path, method: 'POST' do
-        = hidden_field_tag :redirect_to, request.fullpath
-        = render partial: 'rhea/commands/table', locals: { commands: @commands }
-    - else
-      %p No commands found.
+    .row
+      .col-md-12
+        .pull-left
+          = form_tag commands_path, method: 'GET', class: 'form-inline' do
+            .form-group
+              = label_tag :image, 'Image', style: 'margin-right: 5px; font-size: 13px;'
+              - image_options = [['All', nil]] + @images.map { |image| [humanize_image(image), image] }
+              = select_tag :image, options_for_select(image_options, params[:image].presence), class: 'form-control', onchange: "$(this).closest('form').submit();"
+        .pull-right
+          = form_tag import_commands_path, method: 'PUT', multipart: true, style: 'display: inline-block;' do
+            %span.btn.btn-default.btn-file
+              Import
+              = file_field_tag :data, accept: 'application/json', onchange: "$(this).closest('form').submit();"
+          = link_to 'Export', export_commands_path(format: 'json'), class: 'btn btn-default'
+        %br
+        %br
+        %br
+    .row
+      .col-md-12
+        - if @commands.present?
+          = form_tag batch_update_commands_path, method: 'POST' do
+            = hidden_field_tag :redirect_to, request.fullpath
+            = render partial: 'rhea/commands/table', locals: { commands: @commands }
+        - else
+          %p
+            No commands found.
 
   .col-md-4
     .panel.panel-default


### PR DESCRIPTION
### Before

Previously, the commands table was on the same `.row` as the filter elements, which made its empty state look odd:

<img width="843" alt="screen shot 2016-07-31 at 8 46 31 pm" src="https://cloud.githubusercontent.com/assets/193898/17282990/98b8b84c-5760-11e6-8e55-a98d69fe4be8.png">

Also, the table didn't have much vertical padding between itself and the filter elements:

<img width="843" alt="screen shot 2016-07-31 at 8 46 45 pm" src="https://cloud.githubusercontent.com/assets/193898/17282994/9ca7cde4-5760-11e6-93d3-26edb11b7b1e.png">

### After

This uses two `.row`s: one for the filter elements and one for the commands table:

<img width="842" alt="screen shot 2016-07-31 at 8 45 17 pm" src="https://cloud.githubusercontent.com/assets/193898/17283008/ced9463a-5760-11e6-8ee5-71410298ddec.png">

And it adds a little vertical padding between the filter elements and the table:

<img width="843" alt="screen shot 2016-07-31 at 8 45 01 pm" src="https://cloud.githubusercontent.com/assets/193898/17283016/e35e7116-5760-11e6-89ca-3e160041b100.png">
